### PR TITLE
Add missing exports

### DIFF
--- a/packages/custom-carbon-addons/src/apollo-client-hooks/index.js
+++ b/packages/custom-carbon-addons/src/apollo-client-hooks/index.js
@@ -3,8 +3,8 @@
  */
 /* eslint import/no-unresolved: [2, { ignore: ['devenv_pkg*.'] }] */
 import { ApolloClientHooks } from 'devenv_pkg/src/apollo-client-hooks';
+import { renderers, sampleRenderers }  from 'devenv_pkg/src';
 import * as CustomApolloClientHooks from './hooks/components';
-
 
 // ApolloClientHooks object initially has the list of sample components to be renderered
 // The custom appollo client hooks are automatically added to the sample ones below
@@ -13,4 +13,4 @@ import * as CustomApolloClientHooks from './hooks/components';
 const updatedApolloClientHooks = { ...ApolloClientHooks, ...CustomApolloClientHooks };
 
 // eslint-disable-next-line import/prefer-default-export
-export { updatedApolloClientHooks as ApolloClientHooks };
+export { updatedApolloClientHooks as ApolloClientHooks, renderers, sampleRenderers };

--- a/packages/custom-carbon-addons/src/apollo-client-hooks/index.js
+++ b/packages/custom-carbon-addons/src/apollo-client-hooks/index.js
@@ -3,7 +3,6 @@
  */
 /* eslint import/no-unresolved: [2, { ignore: ['devenv_pkg*.'] }] */
 import { ApolloClientHooks } from 'devenv_pkg/src/apollo-client-hooks';
-import { renderers, sampleRenderers }  from 'devenv_pkg/src';
 import * as CustomApolloClientHooks from './hooks/components';
 
 // ApolloClientHooks object initially has the list of sample components to be renderered
@@ -13,4 +12,4 @@ import * as CustomApolloClientHooks from './hooks/components';
 const updatedApolloClientHooks = { ...ApolloClientHooks, ...CustomApolloClientHooks };
 
 // eslint-disable-next-line import/prefer-default-export
-export { updatedApolloClientHooks as ApolloClientHooks, renderers, sampleRenderers };
+export { updatedApolloClientHooks as ApolloClientHooks };

--- a/packages/custom-carbon-addons/src/index.js
+++ b/packages/custom-carbon-addons/src/index.js
@@ -1,0 +1,9 @@
+/*
+ * Copyright Merative US L.P. 2021
+ */
+
+/* eslint import/no-unresolved: [2, { ignore: ['devenv_pkg*.'] }] */
+import { renderers, sampleRenderers }  from 'devenv_pkg/src';
+
+// eslint-disable-next-line import/prefer-default-export
+export { renderers, sampleRenderers };


### PR DESCRIPTION
@bdjos1 from our discussion 2024-04-04 11:31am

"We seem to be missing an index.js file at the root of src directory of the custom-carbon-addons package. It should reference the renderers/index.js and apollo-client-hooks/index.js (weird pretty sure we had this in the second last release) - but for now just hacked the apollo-client-hooks/index.js file as seen to add the sampleRenderers import and also export"

I have added the missing `index.js` file. The sample components will not render otherwise.
