### PR TITLE
Remove unused bower_components reference from webpack config

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,6 @@ module.exports = {
       },
       {
         test: /\.(js|jsx)$/,
-        exclude: /(bower_components)/,
         loader: "babel-loader",
         options: { presets: ["@babel/env"] },
       },


### PR DESCRIPTION
Remove unused `bower_components` reference from webpack config
