### PR TITLE
Move 'subpkg' from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,6 @@
     "sass-loader": "^10.0.3",
     "shelljs": "^0.8.5",
     "style-loader": "^0.23.0",
-    "subpkg": "^4.1.0",
     "webpack": "4.42.1",
     "webpack-bundle-analyzer": "3.6.1",
     "webpack-cli": "4.10.0",
@@ -104,7 +103,8 @@
     "react-app-polyfill": "^1.0.6",
     "react-dom": "^16.13.1",
     "react-intl": "^2.8.0",
-    "regenerator-runtime": "^0.13.7"
+    "regenerator-runtime": "^0.13.7",
+    "subpkg": "^4.1.0"
   },
   "resolutions": {
     "immer": "9.0.6",


### PR DESCRIPTION
Move the dependency on `subpkg` from devDependencies to dependencies as it is required when running the license report which does a production install.
