### PR TITLE
Fix instructions

### DIFF
--- a/cookbook/src/pages/setup.mdx
+++ b/cookbook/src/pages/setup.mdx
@@ -3,9 +3,9 @@ title: Setting up your development environment
 description: Setting up your development environment
 ---
 
-1. Download and install Node.js from [https://nodejs.org](https://nodejs.org). The installation includes the npm (Node package manager), which you can use to install your Node packages.
-2. Download and install your IDE. Microsoft Visual Studio Code [https://code.visualstudio.com/download](https://code.visualstudio.com/download) is the recommended IDE. Install any needed extensions, such as ESLint or Prettier.
-3. Download the `main` branch of the Cúram UI Addon Development Environment code from [https://github.com/merative/spm-ui-addon-devenv](https://github.com/merative/spm-ui-addon-devenv).
+1. Download and install Node.js from https://nodejs.org. The installation includes the npm (Node package manager), which you can use to install your Node packages.
+2. Download and install your IDE. Microsoft Visual Studio Code (https://code.visualstudio.com/download) is the recommended IDE.
+3. Download the appropriate release of the Cúram UI Addon Development Environment from https://github.com/merative/spm-ui-addon-devenv/releases.
 
    You can choose one of the following options:
 


### PR DESCRIPTION
https://merative.atlassian.net/browse/SPM-133892

Instructions were saying to download `main` but instead customers should download the latest release tag.

Also fix some unnecessary link formatting.
