### PR TITLE
Remove unnecessary node_options flag

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-// Added to fix https://github.com/webpack/webpack/issues/14532 when upgrading to NodeJs 20. Remove when we upgrade to Webpack 5.
-node-options="--openssl-legacy-provider"


### PR DESCRIPTION
https://merative.atlassian.net/browse/SPM-132761

Now that we have upgraded to Webpack 5 we can remove the `--openssl-legacy-provider` flag
