### PR TITLE
SPM-138844 Fix prerequisite versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2.0.0 - TBD ![SPM 8.0.1 and later](https://img.shields.io/badge/-SPM_8.0.1%20and%20later-green)
+## 2.0.0 - TBD ![SPM 8.1.0 and later](https://img.shields.io/badge/-SPM_8.1.0%20and%20later-green)
 
 ### Added
 

--- a/cookbook/src/pages/prerequisites.mdx
+++ b/cookbook/src/pages/prerequisites.mdx
@@ -18,7 +18,7 @@ Node.js is a prerequisite for installing the Cúram UI Addon Development Environ
 | :------------------------------- | :------------------ | :--------- |
 | 1.0.0                            | 8.0.1, 8.0.2, 8.0.3 | v10        |
 | 1.1.0                            | 8.0.1, 8.0.2, 8.0.3 | v10        |
-| 2.0.0                            | 8.0.1 or later      | v11        |
+| 2.0.0                            | 8.1.0 or later      | v11        |
 
 ## Integrated Development Environment (IDE)
 


### PR DESCRIPTION
https://merative.atlassian.net/browse/SPM-138844

The prerequisite versions in spm-ui-addon-devenv 2.0.0 state that the code can be used with Curam 8.0.1 onwards. This is incorrect. The code can only be used with Curam 8.1.0 onwards, as that was when we upgraded Curam to Carbon 11.
